### PR TITLE
Potential fix for code scanning alert no. 30: Missing rate limiting

### DIFF
--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -6,7 +6,6 @@ import bcrypt from 'bcryptjs'
 import jwt from 'jsonwebtoken'
 import { TOTPService } from '../services/totp.js'
 import { PasskeyService } from '../services/passkey.js'
-// import { RateLimitService } from '../services/rateLimit.js'; // Remove custom rate limit service
 import rateLimit from '@fastify/rate-limit';
 // Global type extension for OIDC state storage
 declare global {
@@ -41,21 +40,6 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
   };
   // Login
   fastify.post('/login', {
-    // Remove custom preHandler for rate limiting, rely on @fastify/rate-limit
-    // preHandler: async (request, reply) => {
-    //   // Use RateLimitService to enforce rate limiting for login attempts
-    //   // Allow max 5 requests per 15 minutes per IP
-    //   await RateLimitService.check(request, reply, {
-    //     key: request.ip,
-    //     max: 5,
-    //     timeWindow: 15 * 60, // seconds
-    //     errorResponse: {
-    //       code: 429,
-    //       error: 'Too Many Login Attempts',
-    //       message: 'Too many login attempts. Please wait 15 minutes before trying again.'
-    //     }
-    //   });
-    // },
     config: {
       rateLimit: {
         max: 5,


### PR DESCRIPTION
Potential fix for [https://github.com/ulm0/leelo/security/code-scanning/30](https://github.com/ulm0/leelo/security/code-scanning/30)

To fix the problem, we should add a robust rate-limiting middleware to the `/login` route. The recommended approach for Fastify is to use the official `@fastify/rate-limit` plugin, which is well-maintained and widely used. We should import and register this plugin in the Fastify instance, and then apply per-route rate limiting to the `/login` endpoint. This can be done by adding a `config: { rateLimit: ... }` block to the route options, which is already present, but we must ensure the plugin is registered and active. If the plugin is not registered in this file, we should do so. If the plugin is registered elsewhere, we should ensure the per-route config is correct.

**Required changes:**
- Import and register `@fastify/rate-limit` in the Fastify instance (if not already done).
- Ensure the `/login` route has a `config.rateLimit` block with appropriate settings (already present).
- Remove or update the custom `RateLimitService.check` in the `preHandler` to avoid redundancy/conflicts.
- Add any necessary imports for the plugin.

All changes must be made within the code shown in `src/server/routes/auth.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
